### PR TITLE
Handle arrays as the root object.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const camelCase = (str) => str.replace(/[_.-](\w|$)/g, (_, x) => x.toUpperCase()
 
 function camelCaseRecursive(obj) {
 
-  return obj == null ? obj : mapObj(obj, (key, val) => {
+  const transform = obj == null ? obj : mapObj(obj, (key, val) => {
     const newArray = [];
 
     if (Array.isArray(val)) {
@@ -29,6 +29,9 @@ function camelCaseRecursive(obj) {
 
     return [camelCase(key), val];
   });
+
+  return (Array.isArray(obj) ? Object.values(transform) : transform);
+
 }
 
 export default camelCaseRecursive;

--- a/test/index.js
+++ b/test/index.js
@@ -169,3 +169,24 @@ describe('Handling undefined root object', () => {
   });
 
 });
+
+describe('Handling array root object', () => {
+
+  it('Should not throw Error', () => {
+    const fn = function testThrowError() {
+      return camelCaseKeys([]);
+    };
+    expect(fn).to.not.throw(Error);
+  });
+
+  it('Should return an array', () => {
+    expect(camelCaseKeys([])).to.be.instanceof(Array);
+  });
+
+  it('Should handle nested objects', () => {
+    const expected = [{test1: 123}];
+    const actual = camelCaseKeys([{'test-1': 123}]);
+    expect(camelCaseKeys(actual)).to.deep.equal(expected);
+  });
+
+});


### PR DESCRIPTION
Hi there! We're using this for JSON serialization/deserialization. Thanks for the project.

We noticed that although the library handles nested arrays well, if you give it an array as an initial value, you get the mapObj back. So, this PR just casts the mapObj it back to an array if the input was one.