### PR TITLE
Object.values not supported in many browsers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,12 @@ const isObject = (v) => typeof(v) === 'object';
 
 const camelCase = (str) => str.replace(/[_.-](\w|$)/g, (_, x) => x.toUpperCase());
 
+function objectValues(obj) {
+  return Object.keys(obj).map(function(key) {
+    return obj[key];
+  });
+}
+
 function camelCaseRecursive(obj) {
 
   const transform = obj == null ? obj : mapObj(obj, (key, val) => {
@@ -30,7 +36,7 @@ function camelCaseRecursive(obj) {
     return [camelCase(key), val];
   });
 
-  return (Array.isArray(obj) ? Object.values(transform) : transform);
+  return (Array.isArray(obj) ? objectValues(transform) : transform);
 
 }
 


### PR DESCRIPTION
Using this library today I noticed that it throws an error `Object.values is not a function` in Chrome 53 because Object.values is not supported. (It seems as of Chrome 51 the feature is behind a flag.)

I've changed it so that it doesn't rely on `Object.values` which will make this library more cross-browser compatible.

EDIT: you could also add the `Object.values` shim yourself with something like `core-js`. If you'd prefer that approach could you let me know? I'd be happy to submit a PR for that.