### PR TITLE
Handle white spaces in key names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import mapObj from 'map-obj';
 
 const isObject = (v) => typeof(v) === 'object';
 
-const camelCase = (str) => str.replace(/[_.-](\w|$)/g, (_, x) => x.toUpperCase());
+const camelCase = (str) => str.replace(/[ _.-](\w|$)/g, (_, x) => x.toUpperCase());
 
 function objectValues(obj) {
   return Object.keys(obj).map(function(key) {

--- a/test/index.js
+++ b/test/index.js
@@ -138,6 +138,40 @@ describe('Nested keys within arrays and objects are camelCased', () => {
 
   });
 
+  it('Should camelCase keys with white spaces', () => {
+
+    const anotherCamelWithTheHump = camelCaseKeys({
+      'test 1': 123,
+      'test-Two': [{
+        'test three': {
+          'test-FOUR': [{
+            'test-five': [{
+              'test-six': {
+                'test-seven': [1, 4, [1, 2, '3', 'four', 'five-one']]
+              }
+            }]
+          }]
+        }
+      }]
+    });
+
+    expect(anotherCamelWithTheHump).deep.equals({
+      test1: 123,
+      testTwo: [{
+        testThree: {
+          testFOUR: [{
+            testFive: [{
+              testSix: {
+                testSeven: [1, 4, [1, 2, '3', 'four', 'five-one']]
+              }
+            }]
+          }]
+        }
+      }]
+    });
+
+  });
+
 });
 
 describe('Handling null root object', () => {


### PR DESCRIPTION
## Issue
Currently, if a key has a white space, it is not camel cased.
```js
const obj = { 'key 1': 'value 1', 'key-2': 'value 2' }
// --> { 'key 1': 'value 1', 'key2': 'value 2' }
```

## Expected
```js
const obj = { 'key 1': 'value 1', 'key-2': 'value 2' }
// --> { 'key1': 'value 1', 'key2': 'value 2' }
```

## Solution
Alter the regex to handle white space too.

## Todo list
- [x] Regex updated
- [x] Feature covered by a test